### PR TITLE
setup-switch: fix typo "Seting" -> "Setting"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ your actual networking interface is.
 
 You should see:
 
-	Seting up switch on tap0
+	Setting up switch on tap0
 	net.ipv4.ip_forward = 1
 
 That should get your system setup for networking. It will allow your guests to

--- a/setup-switch
+++ b/setup-switch
@@ -121,7 +121,7 @@ setup_nat() {
 	add_filter_rules "$1"
 }
 
-echo Seting up switch on $TAP_DEV
+echo Setting up switch on $TAP_DEV
 
 start_vdeswitch
 do_ifconfig $TAP_DEV "$GATEWAY" netmask "$NETMASK" up


### PR DESCRIPTION
Fix the typo "Seting" in a status message to "Setting". Also update the
example output in README.md accordingly.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>